### PR TITLE
Fix player input

### DIFF
--- a/lib/utilities/input.rb
+++ b/lib/utilities/input.rb
@@ -1,0 +1,19 @@
+class Input
+  @@pressed = []
+
+  def self.pressed(input)
+    @@pressed << input
+  end
+
+  def self.pressing?(input)
+    @@pressed.include?(input)
+  end
+
+  def self.released(input)
+    @@pressed.delete(input)
+  end
+
+  def self.released?(input)
+    !pressing(input)
+  end
+end

--- a/lib/utilities/input.rb
+++ b/lib/utilities/input.rb
@@ -1,19 +1,21 @@
 class Input
-  @@pressed = []
-
-  def self.pressed(input)
-    @@pressed << input
+  def initialize()
+    @pressed = []
   end
 
-  def self.pressing?(input)
-    @@pressed.include?(input)
+  def pressed(input)
+    @pressed << input
   end
 
-  def self.released(input)
-    @@pressed.delete(input)
+  def pressing?(input)
+    @pressed.include?(input)
   end
 
-  def self.released?(input)
+  def released(input)
+    @pressed.delete(input)
+  end
+
+  def released?(input)
     !pressing(input)
   end
 end

--- a/src/main.rb
+++ b/src/main.rb
@@ -1,6 +1,7 @@
 require_relative '../lib/rendering/context.rb'
 require_relative '../lib/factories/factories.rb'
 require_relative '../lib/utilities/inputs.rb'
+require_relative '../lib/utilities/input.rb'
 require_relative '../lib/math/all.rb'
 
 context = Rendering::Context.new(800, 600, 5)
@@ -12,18 +13,23 @@ tileset = Factories::Tileset.create(16, 16, './assets/default_tileset.png')
 map     = Factories::Map.create('assets/map.csv', tileset)
 sprite  = Factories::Sprite.create('./assets/default_sprite.png', 16, 16)
 
-window.on_input_pressed = Proc.new do |input_id|
-  case input_id
-    when INPUTS::W_KEY
-      sprite.change_position(sprite.position + Vector2D.new(0,-1))
-    when INPUTS::S_KEY
-      sprite.change_position(sprite.position + Vector2D.new(0, 1))
-    when INPUTS::A_KEY
-      sprite.change_position(sprite.position + Vector2D.new(-1, 0))
-    when INPUTS::D_KEY
-      sprite.change_position(sprite.position + Vector2D.new(1, 0))
-    when INPUTS::ESC_KEY
-      window.close!
+window.on_input_pressed = Proc.new { |input_id| Input.pressed(input_id) }
+window.on_input_released = Proc.new { |input_id| Input.released(input_id) }
+window.update = Proc.new do |delta|
+  if Input.pressing?(INPUTS::W_KEY)
+    sprite.change_position(sprite.position + Vector2D.new(0,-1))
+  end
+  if Input.pressing?(INPUTS::S_KEY)
+    sprite.change_position(sprite.position + Vector2D.new(0, 1))
+  end
+  if Input.pressing?(INPUTS::A_KEY)
+    sprite.change_position(sprite.position + Vector2D.new(-1, 0))
+  end
+  if Input.pressing?(INPUTS::D_KEY)
+    sprite.change_position(sprite.position + Vector2D.new(1, 0))
+  end
+  if Input.pressing?(INPUTS::ESC_KEY)
+    window.close!
   end
   camera.set_position(sprite.position)
 end

--- a/src/main.rb
+++ b/src/main.rb
@@ -4,7 +4,7 @@ require_relative '../lib/utilities/inputs.rb'
 require_relative '../lib/utilities/input.rb'
 require_relative '../lib/math/all.rb'
 
-input_manager = Input.new()
+input_state = Input.new()
 context = Rendering::Context.new(800, 600, 5)
 camera  = Factories::Camera.create(Vector2D.new(0,0), Rect.new(0, 0, 800, 600))
 window  = Factories::Window.create("Tiled Nostalgia", context)
@@ -14,22 +14,22 @@ tileset = Factories::Tileset.create(16, 16, './assets/default_tileset.png')
 map     = Factories::Map.create('assets/map.csv', tileset)
 sprite  = Factories::Sprite.create('./assets/default_sprite.png', 16, 16)
 
-window.on_input_pressed = Proc.new { |input_id| input_manager.pressed(input_id) }
-window.on_input_released = Proc.new { |input_id| input_manager.released(input_id) }
+window.on_input_pressed = Proc.new { |input_id| input_state.pressed(input_id) }
+window.on_input_released = Proc.new { |input_id| input_state.released(input_id) }
 window.update = Proc.new do |delta|
-  if input_manager.pressing?(INPUTS::W_KEY)
+  if input_state.pressing?(INPUTS::W_KEY)
     sprite.change_position(sprite.position + Vector2D.new(0,-1))
   end
-  if input_manager.pressing?(INPUTS::S_KEY)
+  if input_state.pressing?(INPUTS::S_KEY)
     sprite.change_position(sprite.position + Vector2D.new(0, 1))
   end
-  if input_manager.pressing?(INPUTS::A_KEY)
+  if input_state.pressing?(INPUTS::A_KEY)
     sprite.change_position(sprite.position + Vector2D.new(-1, 0))
   end
-  if input_manager.pressing?(INPUTS::D_KEY)
+  if input_state.pressing?(INPUTS::D_KEY)
     sprite.change_position(sprite.position + Vector2D.new(1, 0))
   end
-  if input_manager.pressing?(INPUTS::ESC_KEY)
+  if input_state.pressing?(INPUTS::ESC_KEY)
     window.close!
   end
   camera.set_position(sprite.position)

--- a/src/main.rb
+++ b/src/main.rb
@@ -4,6 +4,7 @@ require_relative '../lib/utilities/inputs.rb'
 require_relative '../lib/utilities/input.rb'
 require_relative '../lib/math/all.rb'
 
+input_manager = Input.new()
 context = Rendering::Context.new(800, 600, 5)
 camera  = Factories::Camera.create(Vector2D.new(0,0), Rect.new(0, 0, 800, 600))
 window  = Factories::Window.create("Tiled Nostalgia", context)
@@ -13,22 +14,22 @@ tileset = Factories::Tileset.create(16, 16, './assets/default_tileset.png')
 map     = Factories::Map.create('assets/map.csv', tileset)
 sprite  = Factories::Sprite.create('./assets/default_sprite.png', 16, 16)
 
-window.on_input_pressed = Proc.new { |input_id| Input.pressed(input_id) }
-window.on_input_released = Proc.new { |input_id| Input.released(input_id) }
+window.on_input_pressed = Proc.new { |input_id| input_manager.pressed(input_id) }
+window.on_input_released = Proc.new { |input_id| input_manager.released(input_id) }
 window.update = Proc.new do |delta|
-  if Input.pressing?(INPUTS::W_KEY)
+  if input_manager.pressing?(INPUTS::W_KEY)
     sprite.change_position(sprite.position + Vector2D.new(0,-1))
   end
-  if Input.pressing?(INPUTS::S_KEY)
+  if input_manager.pressing?(INPUTS::S_KEY)
     sprite.change_position(sprite.position + Vector2D.new(0, 1))
   end
-  if Input.pressing?(INPUTS::A_KEY)
+  if input_manager.pressing?(INPUTS::A_KEY)
     sprite.change_position(sprite.position + Vector2D.new(-1, 0))
   end
-  if Input.pressing?(INPUTS::D_KEY)
+  if input_manager.pressing?(INPUTS::D_KEY)
     sprite.change_position(sprite.position + Vector2D.new(1, 0))
   end
-  if Input.pressing?(INPUTS::ESC_KEY)
+  if input_manager.pressing?(INPUTS::ESC_KEY)
     window.close!
   end
   camera.set_position(sprite.position)


### PR DESCRIPTION
Input state wasnt maintained making it hard to apply continuous movement.
This PR aims to provide a maintained version of the input state thats queryable.

Key Features:
- Input class to hold and query input state
- input state instance added to main application for smooth sprite movement.