### PR TITLE
Create player node

### DIFF
--- a/lib/nodes/scene_node.rb
+++ b/lib/nodes/scene_node.rb
@@ -1,0 +1,30 @@
+require_relative '../utilities/tree_node.rb'
+require_relative '../math/vector2d.rb'
+
+class SceneNode < TreeNode
+  attr_reader :position
+
+  def initialize(name, position=Vector2D.new(0.0, 0.0))
+    super(name)
+
+    @position = position
+  end
+
+  def position=(new__position)
+    raise ArgumentError, 'position must be a Vector2D' unless new__position.is_a?(Vector2D)
+
+    @position = new__position
+  end
+
+  def input(state)
+    children.each { |child| child.input(state) }
+  end
+
+  def update(delta)
+    children.each { |child| child.update(delta) }
+  end
+
+  def draw
+    children.each(&:draw)
+  end
+end

--- a/lib/nodes/sprite_node.rb
+++ b/lib/nodes/sprite_node.rb
@@ -1,0 +1,19 @@
+require_relative './scene_node.rb'
+require_relative '../factories/factories.rb'
+
+class SpriteNode < SceneNode
+  def initialize(name)
+    super(name)
+
+    # TODO: make it so you can supply the sprite instead?
+    @sprite = Factories::Sprite.create('./assets/default_sprite.png', 16, 16)
+  end
+
+  def update(delta)
+    @sprite.change_position(@position)
+  end
+
+  def draw
+    @sprite.draw
+  end
+end

--- a/lib/utilities/tree_node.rb
+++ b/lib/utilities/tree_node.rb
@@ -1,9 +1,8 @@
-class TreeNode < SimpleDelegator
-  attr_reader :parent
+class TreeNode
+  attr_reader :parent, :name
 
-  def initialize(object)
-    super(object)
-
+  def initialize(name)
+    @name=name
     @children = []
     @parent = nil
   end
@@ -40,5 +39,16 @@ class TreeNode < SimpleDelegator
 
   def children
     [*@children]
+  end
+
+  def find(path)
+    final_node = path.index('/').nil?
+    if final_node
+      destination_nodes = children.select { |child| child.name == path}
+      destination_nodes.any? ? destination_nodes[0] : nil
+    else
+      delimiter_index = path.index('/')
+      children.map { |child| child.find(path[delimiter_index+1...]) }.compact
+    end
   end
 end

--- a/spec/utilities/tree_node/add_child_spec.rb
+++ b/spec/utilities/tree_node/add_child_spec.rb
@@ -3,8 +3,8 @@ require_relative '../../../lib/utilities/tree_node.rb'
 
 RSpec.describe TreeNode do
   describe 'When adding a child node to root node,' do
-    let(:root) { TreeNode.new(Object.new) }
-    let(:child) { TreeNode.new(Object.new) }
+    let(:root) { TreeNode.new('root') }
+    let(:child) { TreeNode.new('child') }
     subject { root.add_child(child) }
 
     context 'given a root node,' do

--- a/spec/utilities/tree_node/create_spec.rb
+++ b/spec/utilities/tree_node/create_spec.rb
@@ -3,7 +3,7 @@ require_relative '../../../lib/utilities/tree_node.rb'
 
 RSpec.describe TreeNode do
   describe 'When creating a tree,' do
-    subject { TreeNode.new(Object.new) }
+    subject { TreeNode.new('root') }
     context 'given a root node with no children,' do
       it 'should have no parent' do
         expect(subject.parent).to be_nil

--- a/src/main.rb
+++ b/src/main.rb
@@ -3,37 +3,39 @@ require_relative '../lib/factories/factories.rb'
 require_relative '../lib/utilities/inputs.rb'
 require_relative '../lib/utilities/input.rb'
 require_relative '../lib/math/all.rb'
+require_relative '../lib/utilities/tree_node.rb'
+require_relative '../lib/nodes/sprite_node.rb'
+require_relative 'nodes/player_node.rb'
 
 input_state = Input.new()
 context = Rendering::Context.new(800, 600, 5)
 camera  = Factories::Camera.create(Vector2D.new(0,0), Rect.new(0, 0, 800, 600))
 window  = Factories::Window.create("Tiled Nostalgia", context)
-window.set_camera(camera)
+window.set_camera(camera) #TODO: make a camera node!
 
+# TODO make a map node
 tileset = Factories::Tileset.create(16, 16, './assets/default_tileset.png')
 map     = Factories::Map.create('assets/map.csv', tileset)
-sprite  = Factories::Sprite.create('./assets/default_sprite.png', 16, 16)
+
+
+# TODO: make this configurable in a scene file?
+root = SceneNode.new('root')
+player_node = PlayerNode.new('player')
+player_sprite = SpriteNode.new('sprite')
+player_node << player_sprite
+root << player_node
+
 
 window.on_input_pressed = Proc.new { |input_id| input_state.pressed(input_id) }
 window.on_input_released = Proc.new { |input_id| input_state.released(input_id) }
 window.update = Proc.new do |delta|
-  if input_state.pressing?(INPUTS::W_KEY)
-    sprite.change_position(sprite.position + Vector2D.new(0,-1))
-  end
-  if input_state.pressing?(INPUTS::S_KEY)
-    sprite.change_position(sprite.position + Vector2D.new(0, 1))
-  end
-  if input_state.pressing?(INPUTS::A_KEY)
-    sprite.change_position(sprite.position + Vector2D.new(-1, 0))
-  end
-  if input_state.pressing?(INPUTS::D_KEY)
-    sprite.change_position(sprite.position + Vector2D.new(1, 0))
-  end
   if input_state.pressing?(INPUTS::ESC_KEY)
     window.close!
   end
-  camera.set_position(sprite.position)
+
+  root.input(input_state)
+  root.update(0.016)
 end
 
-window.draw = -> { map.draw and sprite.draw }
+window.draw = -> { map.draw and root.draw }
 window.show

--- a/src/nodes/player_node.rb
+++ b/src/nodes/player_node.rb
@@ -1,0 +1,41 @@
+require 'byebug'
+
+class PlayerNode < SceneNode
+
+  def initialize(name)
+    super(name)
+    @speed = 10.0
+    @movement_direction = Vector2D.new(0.0, 0.0)
+  end
+
+  def input(state)
+    super(state)
+    y_direction = 0
+    x_direction = 0
+
+    if state.pressing?(INPUTS::W_KEY)
+      y_direction = -1
+    elsif state.pressing?(INPUTS::S_KEY)
+      y_direction=1
+    else
+      y_direction = 0
+    end
+
+    if state.pressing?(INPUTS::A_KEY)
+      x_direction = -1
+    elsif state.pressing?(INPUTS::D_KEY)
+      x_direction = 1
+    else
+      x_direction = 0
+    end
+
+    @movement_direction = Vector2D.new(x_direction, y_direction)
+  end
+
+  def update(delta)
+    super(delta)
+    @position = @position + (@movement_direction * @speed * delta)
+    @sprite ||= find('sprite')
+    @sprite.position = @position
+  end
+end


### PR DESCRIPTION
This PR make significant changes to the TreeNode system.
It also adds the followng features:

- TreeNode is now a concrete class
- SceneNode is now a scene specfic version of a TreeNode
- Adds a sprite node to the list of available node
- Adds a player class as an example of how to use the node system to divide and conquer domain logic.

All tests passing at time of creation.