### PR TITLE
Add root search to node system

### DIFF
--- a/lib/utilities/tree_node.rb
+++ b/lib/utilities/tree_node.rb
@@ -51,4 +51,16 @@ class TreeNode
       children.map { |child| child.find(path[delimiter_index+1...]) }.compact
     end
   end
+
+  def root
+    find_root_of(self)
+  end
+
+  protected
+
+  def find_root_of(node=self)
+    return node if node.parent.nil?
+
+    find_root_of(node.parent)
+  end
 end

--- a/spec/utilities/tree_node/find_root_spec.rb
+++ b/spec/utilities/tree_node/find_root_spec.rb
@@ -1,0 +1,45 @@
+require 'rspec'
+require_relative '../../../lib/utilities/tree_node.rb'
+
+RSpec.describe TreeNode do
+  let(:root) { TreeNode.new('root') }
+  let(:branch_node) { TreeNode.new('branch') }
+  let(:leaf_node) { TreeNode.new('leaf') }
+
+  before(:each) do
+    branch_node << leaf_node
+    root << branch_node
+  end
+
+  describe 'When searching asking for the root node,' do
+    context 'given the node is a leaf node,' do
+      it 'should not return itself' do
+        expect(leaf_node.root).not_to be(leaf_node)
+      end
+
+      it 'should not return a branch node' do
+        expect(leaf_node.root).not_to be(branch_node)
+      end
+
+      it 'should return the root node' do
+        expect(leaf_node.root).to be(root)
+      end
+    end
+
+    context 'given the node is a branch node,' do
+      it 'should not return itself' do
+        expect(branch_node.root).not_to be(branch_node)
+      end
+
+      it 'should return the root node' do
+        expect(branch_node.root).to be(root)
+      end
+    end
+
+    context 'given the node is a root node,' do
+      it 'should return itself' do
+        expect(root.root).to be(root)
+      end
+    end
+  end
+end

--- a/src/todo.md
+++ b/src/todo.md
@@ -1,0 +1,7 @@
+# TODO
+
+- [ ] Create resource objects for things like textures for sprites etc
+- [ ] Create loadable yaml file for scenes/scene trees
+- [ ] Implement static thread safe root node
+- [ ] Create Camera node
+- [ ] Make position relative to parent node


### PR DESCRIPTION
Adds root node search to TreeNode which is then available in all decendants.

This is going to be used for a number of things, but will mainly for the refactor from position being relative to a nodes parent and calculating global positions.